### PR TITLE
chore: add testing infrastructure and test plan

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @artifact-keeper/plugins

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Summary
+<!-- What does this PR do and why? -->
+
+## Test Checklist
+- [ ] `cargo check` passes
+- [ ] `cargo test` passes on host target
+- [ ] `cargo build --release` produces valid WASM
+- [ ] Manually tested plugin loading (if applicable)
+- [ ] No regressions in existing tests

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -1,0 +1,43 @@
+# WASM Plugin Test Plan
+
+## Overview
+
+The artifact-keeper example plugin is a Rust WASM plugin template using wit-bindgen. It compiles to wasm32-wasip1 and implements the FormatHandler WIT contract.
+
+## Test Inventory
+
+| Test Type | Framework | Count | CI Job | Status |
+|-----------|-----------|-------|--------|--------|
+| Check | cargo check | Full | `check` | Active |
+| Format | cargo fmt | Full | CI | Active |
+| Lint | cargo clippy | Full | CI | Active |
+| Unit | cargo test | Minimal | `test` | Active |
+| WASM build | cargo build --release | Full | `build` | Active |
+| Integration | (none) | 0 | - | Missing |
+
+## How to Run
+
+### Check and Lint
+```bash
+cargo check --workspace
+cargo fmt --check
+cargo clippy --workspace -- -D warnings
+```
+
+### Unit Tests (must run on host, not WASM target)
+```bash
+cargo test --target $(rustc -vV | grep host | awk '{print $2}')
+```
+
+### Build WASM
+```bash
+cargo build --release
+# Output: target/wasm32-wasip1/release/unity_format_plugin.wasm
+```
+
+## Gaps and Roadmap
+
+| Gap | Recommendation | Priority |
+|-----|---------------|----------|
+| No integration test | Add test that loads WASM in wasmtime and calls FormatHandler methods | P2 |
+| No plugin lifecycle test | Test register, upload, download, list cycle | P3 |


### PR DESCRIPTION
## Summary
- Add CODEOWNERS for automatic PR review routing to the Plugin Ecosystem team
- Add PR template with WASM-specific test checklist
- Add test plan documenting current state and gaps

## Test plan
- [ ] Verify CODEOWNERS triggers review on next PR
- [ ] Verify PR template appears on new PRs