### PR TITLE
Add SonarCloud scanning to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,8 @@ jobs:
         with:
           name: plugin-wasm
           path: target/wasm32-wasip1/release/unity_format_plugin.wasm
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey=artifact-keeper_artifact-keeper-example-plugin
+sonar.organization=artifact-keeper
+sonar.sources=src
+sonar.exclusions=target/**
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- Add `sonar-project.properties` with project configuration for SonarCloud
- Add SonarCloud scan step to the CI workflow, running after tests and the WASM build

## Test plan
- [ ] Verify `SONAR_TOKEN` secret is configured in repo settings
- [ ] Confirm SonarCloud scan runs on push to main and on PRs
- [ ] Check SonarCloud dashboard for initial analysis results