### PR TITLE
Switch WASM target from wasip1 to wasip2

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasip1"
+target = "wasm32-wasip2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-wasip1
+          targets: wasm32-wasip2
           components: rustfmt, clippy
 
       - name: Cache cargo
@@ -33,19 +33,19 @@ jobs:
         run: cargo fmt --check
 
       - name: Clippy (WASM target)
-        run: cargo clippy --target wasm32-wasip1 -- -D warnings
+        run: cargo clippy --target wasm32-wasip2 -- -D warnings
 
       - name: Unit tests (host target)
         run: cargo test --target x86_64-unknown-linux-gnu
 
       - name: Build WASM component
-        run: cargo build --release --target wasm32-wasip1
+        run: cargo build --release --target wasm32-wasip2
 
       - name: Upload plugin artifact
         uses: actions/upload-artifact@v4
         with:
           name: plugin-wasm
-          path: target/wasm32-wasip1/release/unity_format_plugin.wasm
+          path: target/wasm32-wasip2/release/unity_format_plugin.wasm
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,15 +17,15 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-wasip1
+          targets: wasm32-wasip2
 
       - name: Build WASM component
-        run: cargo build --release --target wasm32-wasip1
+        run: cargo build --release --target wasm32-wasip2
 
       - name: Prepare release archive
         run: |
           mkdir -p release-staging
-          cp target/wasm32-wasip1/release/unity_format_plugin.wasm release-staging/plugin.wasm
+          cp target/wasm32-wasip2/release/unity_format_plugin.wasm release-staging/plugin.wasm
           cp plugin.toml release-staging/
           cp README.md release-staging/
           cp LICENSE release-staging/

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Use this repo as a starting point for building your own plugins. Fork it, change
 ## Prerequisites
 
 - [Rust](https://rustup.rs/) (stable)
-- The `wasm32-wasip1` target (installed automatically via `rust-toolchain.toml`)
+- The `wasm32-wasip2` target (installed automatically via `rust-toolchain.toml`)
 
 ## Build
 
@@ -27,7 +27,7 @@ cd artifact-keeper-example-plugin
 # Build the WASM component
 cargo build --release
 
-# Output: target/wasm32-wasip1/release/unity_format_plugin.wasm
+# Output: target/wasm32-wasip2/release/unity_format_plugin.wasm
 ```
 
 ## Test

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The artifact-keeper example plugin is a Rust WASM plugin template using wit-bindgen. It compiles to wasm32-wasip1 and implements the FormatHandler WIT contract.
+The artifact-keeper example plugin is a Rust WASM plugin template using wit-bindgen. It compiles to wasm32-wasip2 and implements the FormatHandler WIT contract.
 
 ## Test Inventory
 
@@ -32,7 +32,7 @@ cargo test --target $(rustc -vV | grep host | awk '{print $2}')
 ### Build WASM
 ```bash
 cargo build --release
-# Output: target/wasm32-wasip1/release/unity_format_plugin.wasm
+# Output: target/wasm32-wasip2/release/unity_format_plugin.wasm
 ```
 
 ## Gaps and Roadmap

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "stable"
-targets = ["wasm32-wasip1"]
+targets = ["wasm32-wasip2"]


### PR DESCRIPTION
## Summary

- Switch build target from `wasm32-wasip1` to `wasm32-wasip2` across all configs, CI workflows, and docs
- wasip1 is legacy; WASI preview 2 is stable in Rust and supported by wasmtime 24+
- No code changes needed: wit-bindgen 0.36 and all dependencies build cleanly with wasip2

## Files changed

- `.cargo/config.toml` - default build target
- `rust-toolchain.toml` - toolchain target
- `.github/workflows/ci.yml` - CI build/lint/test target
- `.github/workflows/release.yml` - release build target
- `README.md` - documentation references
- `docs/TEST_PLAN.md` - test plan references

## Test plan

- [x] `cargo build --release --target wasm32-wasip2` succeeds
- [x] `cargo clippy --target wasm32-wasip2 -- -D warnings` passes
- [x] `cargo test --target <host>` passes (12/12 tests)
- [x] `cargo fmt --check` passes
- [ ] CI workflow passes with wasip2 target

Closes #1